### PR TITLE
修改readme中cms:DescribeMetricList为cms:QueryMetricList

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -126,7 +126,7 @@ cdt:ListCdtInternetTraffic
     {
       "Effect": "Allow",
       "Action": [
-        "cms:DescribeMetricList"
+        "cms:QueryMetricList"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
云监控（CMS）中没有名为 cms:DescribeMetricList 的 RAM 权限 Action。
要调用的 API 名称为 DescribeMetricList，但其对应的 RAM 授权 Action 是 cms:QueryMetricList。

这是阿里云 CMS 的标准命名规范：API 名称 ≠ 权限 Action 名称。