### PR TITLE
fix: show online update progress

### DIFF
--- a/docker/updater.sh
+++ b/docker/updater.sh
@@ -15,7 +15,9 @@ mkdir -p "$state_dir"
 rmdir "$lock_dir" 2>/dev/null || true
 
 json_escape() {
-    printf '%s' "$1" | awk 'BEGIN { ORS="" } { gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\r/, ""); printf "%s\\n", $0 }'
+    # Keep serialized values free of trailing characters so the web UI can
+    # match request IDs and commits while polling the status file.
+    printf '%s' "$1" | awk 'BEGIN { ORS="" } { gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\r/, ""); printf "%s", $0 }'
 }
 
 write_status() {

--- a/template.html
+++ b/template.html
@@ -5850,8 +5850,10 @@
 
                 const updateStatusMatchesPending = (data) => {
                     if (!updatePending) return true;
-                    const target = String(data?.target_commit || '').toLowerCase();
-                    const requestID = String(data?.request_id || '');
+                    // Older updater images appended a literal newline to JSON
+                    // identifiers; trim them so upgrades remain trackable.
+                    const target = String(data?.target_commit || '').trim().toLowerCase();
+                    const requestID = String(data?.request_id || '').trim();
                     if (updatePollRequestID && requestID && requestID !== updatePollRequestID) {
                         return false;
                     }


### PR DESCRIPTION
## What changed

- Fix updater status JSON serialization so progress identifiers do not contain an unintended literal newline.
- Trim legacy status identifiers in the frontend so older updater images remain trackable during upgrades.
- Restore stage progress updates and automatic completion refresh behavior.

## Root cause

The updater wrote a literal `\\n` suffix into every JSON string. The frontend compared the resulting `target_commit` and `request_id` values with exact matches, rejected every real status update, and stayed at the initial 5% state.

## Validation

- `go test ./...`
- `sh -n docker/updater.sh`
- updater JSON escape regression check
- frontend inline JavaScript syntax check
- `git diff --check`
- diff secret scan